### PR TITLE
Add dependecies to gemspec and configure Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,5 @@
 # Generated from /home/simon/development/ignore-it/ignore-it.gemspec
-source 'https://rubygems.org'
+source('https://rubygems.org')
+
+# Add dependencies to .gemspec, not here in Gemfile
+gemspec

--- a/ignore_it.gemspec
+++ b/ignore_it.gemspec
@@ -8,4 +8,7 @@ Gem::Specification.new do |s|
   s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
   s.test_files    = s.files.grep(%r{^test/})
   s.require_paths = ["lib"]
+
+  # DEPENDENCIES
+  s.add_development_dependency("rake", "~> 11.3.0")
 end


### PR DESCRIPTION
From now on, if we use gems that are not in the standard library we add them as production or development dependencies into the gempsec file.

Like npm, they can then then be installed for the project by running `bundle install`